### PR TITLE
fix(position): fix positioning of picker when input is hidden

### DIFF
--- a/src/coloris.js
+++ b/src/coloris.js
@@ -149,7 +149,8 @@
     // Show the color picker on click on the input fields that match the selector
     addListener(document, 'click', selector, event => {
       const parent = settings.parent;
-      const coords = event.target.getBoundingClientRect();
+      // When input is of type hidden the bounding client rect is always 0
+      const coords = event.target.type === 'hidden' ? event.target.parent.getBoundingClientRect() : event.target.getBoundingClientRect();
       const scrollY = window.scrollY;
       let reposition = { left: false, top: false };
       let offset = { x: 0, y: 0 };


### PR DESCRIPTION
# Description of the issue
When you try to link Coloris to an hidden input, the Color picker is displayed at the top left corner of the screen

# Example
```html
<div class="c-color-input">
  <input id="color-input-id" type="hidden" value="#FF3344"/>
  <span class="c-color-input__color" {{on 'click' this.openColorPicker}}/>
</div>
```
<img width="48" alt="Capture d’écran 2021-11-09 à 20 57 33" src="https://user-images.githubusercontent.com/3263749/140995952-8e907dbe-d39e-4933-9f8d-30088496aad0.png">
 