### PR TITLE
Fix colorArea bug for inline colorpicker

### DIFF
--- a/src/coloris.js
+++ b/src/coloris.js
@@ -274,14 +274,23 @@
       picker.classList.toggle('clr-top', reposition.top);
       picker.style.left = `${left}px`;
       picker.style.top = `${top}px`;
+      
+      colorAreaDims = {
+        width: colorArea.offsetWidth,
+        height: colorArea.offsetHeight,
+        x: picker.offsetLeft + colorArea.offsetLeft + offset.x,
+        y: picker.offsetTop + colorArea.offsetTop + offset.y
+      };
+    } else {
+      const colorAreaRect = colorArea.getBoundingClientRect();
+
+      colorAreaDims = {
+        width: colorAreaRect.width,
+        height: colorAreaRect.height,
+        x: colorAreaRect.x + scrollX,
+        y: colorAreaRect.y + scrollY
+      };
     }
-    
-    colorAreaDims = {
-      width: colorArea.offsetWidth,
-      height: colorArea.offsetHeight,
-      x: picker.offsetLeft + colorArea.offsetLeft + offset.x,
-      y: picker.offsetTop + colorArea.offsetTop + offset.y
-    };
   }
 
   /**


### PR DESCRIPTION
I moved the old logic for colorAreaDims to be only used when picker is not inline.

If the colorpicker is inline i take the boundingClientRectangle and the scroll to get the current position of the colorArea. With adding the scroll i make the sure the colorArea still works when the website is scrolled and the function gets called.

I will create a 2nd PR with an example for an inline picker to test my fix.