### PR TITLE
Add an option to be use as a div

### DIFF
--- a/src/coloris.js
+++ b/src/coloris.js
@@ -195,7 +195,7 @@
       }
 
       currentEl = event.target;
-      oldColor = currentEl.value;
+      oldColor = currentEl.getAttribute("value");
       currentFormat = getColorFormatFromStr(oldColor);
       picker.classList.add('clr-open');
       


### PR DESCRIPTION
for example:
<div class="coloris" value="rgb(255, 0, 0)">This is an example</div>
without this fix, it will give an error of undefined.