### PR TITLE
Fix #81: a11y switch do not fall through

### DIFF
--- a/src/coloris.js
+++ b/src/coloris.js
@@ -211,6 +211,7 @@
             colorValue.setAttribute('aria-label', settings.a11y.input);
             colorArea.setAttribute('aria-label', settings.a11y.instruction);
           }
+          break;
         default:
           settings[key] = options[key];
       }


### PR DESCRIPTION
Fix #81: a11y switch do not fall through