### PR TITLE
add swtaches edition (swatch = color + name)

### DIFF
--- a/src/coloris.css
+++ b/src/coloris.css
@@ -250,6 +250,7 @@
 
 
 
+
 input.clr-color {
   order: 1;
   width: calc(100% - 80px);
@@ -272,7 +273,8 @@ input.clr-color:focus {
 }
 
 .clr-close,
-.clr-clear {
+.clr-clear,
+.clr-addswatch_bt {
   display: none;
   order: 2;
   height: 24px;
@@ -292,6 +294,64 @@ input.clr-color:focus {
   display: block;
   margin: 0 20px 20px auto;
 }
+
+
+
+
+.clr-addswatch {
+  display: flex;
+  order: 2;
+  width: calc(100% - 32px);
+  margin: 0 16px;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 9px;
+}
+.clr-addswatch_bt
+{
+  display: block;
+  margin: 0 8px 0px;
+}
+
+input.clr-addswatch_ip 
+{
+  order: 1;
+  width: calc(100% - 60px);
+  height: 32px;
+  margin: 3px 0px 4px auto;
+  padding: 0 10px;
+  border: 1px solid #ddd;
+  border-radius: 16px;
+  color: #444;
+  background-color: #fff;
+  font-family: sans-serif;
+  font-size: 14px;
+  text-align: center;
+  box-shadow: none;
+}
+
+input.clr-color:focus {
+  outline: none;
+  border: 1px solid #1e90ff;
+}
+
+.clr-dark input.clr-addswatch_ip {
+  color: #fff;
+  border-color: #777;
+  background-color: #555;
+}
+.clr-dark input.clr-addswatch_ip:focus {
+  border-color: #1e90ff;
+}
+.clr-polaroid input.clr-addswatch_ip {
+  width: calc(100% - 60px);
+  margin: 10px 10px 15px auto;
+}
+
+
 
 .clr-preview {
   position: relative;
@@ -339,7 +399,8 @@ input.clr-color:focus {
 .clr-marker,
 .clr-hue div,
 .clr-alpha div,
-.clr-color {
+.clr-color,
+.clr-addswatch_ip {
   box-sizing: border-box;
 }
 
@@ -427,6 +488,7 @@ input.clr-color:focus {
 .clr-picker[data-minimal="true"] .clr-hue,
 .clr-picker[data-minimal="true"] .clr-alpha,
 .clr-picker[data-minimal="true"] .clr-color,
+.clr-picker[data-minimal="true"] .clr-addswatch,
 .clr-picker[data-minimal="true"] .clr-preview {
   display: none;
 }
@@ -552,9 +614,15 @@ input.clr-color:focus {
   margin: 0 10px 15px 10px;
 }
 
+.clr-polaroid .clr-addswatch_bt {
+  margin: 0 10px 15px 10px;
+}
+
 .clr-polaroid .clr-close {
   margin: 0 10px 15px auto;
 }
+
+
 
 .clr-polaroid .clr-preview {
   margin: 10px 0 15px 10px;

--- a/src/coloris.css
+++ b/src/coloris.css
@@ -12,6 +12,7 @@
   -moz-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /*overflow: hidden;*/   /*to avoid tooltips be out of tool panel. comment it if it's Ok */
 }
 
 .clr-picker.clr-open,
@@ -210,9 +211,7 @@
   border: 0;
   border-radius: 50%;
   color: inherit;
-  text-indent: -1000px;
   white-space: nowrap;
-  overflow: hidden;
   cursor: pointer;
 }
 
@@ -228,6 +227,28 @@
   background-color: currentColor;
   box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
 }
+
+.clr-swatches button .tooltip
+{
+  visibility: hidden;
+  width: 120px;
+  background-color: rgb(255, 255, 255);
+  color: #999;
+  text-align: center;
+  border: 5px solid;
+  border-radius: 10px;
+  padding: 5px 4px;
+  position: absolute;
+  z-index: 1;
+  left: -60px;
+  top: 21px;
+}
+.clr-swatches button:hover .tooltip
+{
+  visibility: visible;
+}
+
+
 
 input.clr-color {
   order: 1;

--- a/src/coloris.js
+++ b/src/coloris.js
@@ -127,7 +127,14 @@
             const swatches = [];
 
             options.swatches.forEach((swatch, i) => {
-              swatches.push(`<button type="button" id="clr-swatch-${i}" aria-labelledby="clr-swatch-label clr-swatch-${i}" style="color: ${swatch};">${swatch}</button>`);
+              let colorStr = swatch;
+              let colorNameStr = swatch;
+              if((swatch.color!=undefined)&&(swatch.color!=null))
+              {
+                colorStr = swatch.color;
+                colorNameStr = ((swatch.name!=undefined)&&(swatch.name!=null)) ? swatch.name : colorStr;
+              }
+              swatches.push(`<button type="button" id="clr-swatch-${i}" aria-labelledby="clr-swatch-label clr-swatch-${i}" style="color: ${colorStr};" data_color="${colorStr}" ><div class="tooltip" style="border-color: ${colorStr}" >${colorNameStr}</div></button>`);
             });
 
             getEl('clr-swatches').innerHTML = swatches.length ? `<div>${swatches.join('')}</div>` : '';
@@ -1023,7 +1030,7 @@
     });
 
     addListener(picker, 'click', '.clr-swatches button', event => {
-      setColorFromStr(event.target.textContent);
+      setColorFromStr(event.target.getAttribute("data_color"));
       pickColor();
 
       if (settings.swatchesOnly) {


### PR DESCRIPTION
It just add a edition of swatches (only on src, not dist).

My modifications : 
-deal with a swatches list = [ {color: "#FF00FF", name: "Color1"} ,  etc ... ]  (use direct "#FF00FF" still continue to work).
-add a tooltip with the name under the swatch color button, on hover.
-add a input (for name edition) + a "Add" button to add a swatch (label and internationnalization is keeped like other buttons).
-use right-click on a swtch color button to delete it. 
-add a onSwatchesChange  (used like onChange) to get the list of swatches (rebuilded from html buttons).
