### PR TITLE
Fix Marker Wrong Position Problem When Enable Inline Mode

### DIFF
--- a/src/coloris.js
+++ b/src/coloris.js
@@ -433,9 +433,10 @@
       picker.classList.toggle('clr-top', reposition.top);
       picker.style.left = `${left}px`;
       picker.style.top = `${top}px`;
-      offset.x += picker.offsetLeft;
-      offset.y += picker.offsetTop;
     }
+
+    offset.x += picker.offsetLeft;
+    offset.y += picker.offsetTop;
     
     colorAreaDims = {
       width: colorArea.offsetWidth,


### PR DESCRIPTION
if set inline true and set parent the marker position get wrong
![GIF 2024-07-20 22-37-49](https://github.com/user-attachments/assets/fe224518-257a-4fb8-901b-b7e79a0323cc)
